### PR TITLE
パラレルノードの修正

### DIFF
--- a/src/core/ai/composite/compositeBehaviour.ts
+++ b/src/core/ai/composite/compositeBehaviour.ts
@@ -2,7 +2,9 @@ import { Behaviour } from '../behaviour'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const parallel = function*(behaviourList: Array<Behaviour<any>>): Behaviour<void> {
-  while (!behaviourList.every(behaviour => behaviour.next().done)) {
+  while (true) {
+    const hasAllDone = behaviourList.map(behaviour => behaviour.next().done).every(done => !!done)
+    if (hasAllDone) break
     yield
   }
 }


### PR DESCRIPTION
`a || po.next().done`とすると、`a === false`のときに後ろの式が評価されないため、`po.next()`が評価されるように修正