### PR TITLE
HPが0を下回らないように修正

### DIFF
--- a/src/core/systems/damageSystem.ts
+++ b/src/core/systems/damageSystem.ts
@@ -49,7 +49,7 @@ export class DamageSystem extends System {
       const invincible = entity.getComponent('Invincible')
       const attack = hitbox.component.entity.getComponent('Attack')
       if (!invincible.isInvincible() && attack.entity !== entity) {
-        hp.hp -= attack.damage
+        hp.hp = Math.max(0, hp.hp - attack.damage)
         invincible.setInvincible()
       }
     }


### PR DESCRIPTION
hpが0になって死亡モーション中にダメージを受けると、負のhpになってしまっていたので、hp側を負の値にならないように修正。
close: #75 