### PR TITLE
Fix: disable enemy's invincible

### DIFF
--- a/src/game/ai/entity/common/condition/isAlive.ts
+++ b/src/game/ai/entity/common/condition/isAlive.ts
@@ -1,7 +1,6 @@
 import { Entity } from '@core/ecs/entity'
 
 export const isAlive = (entity: Entity) => (): boolean => {
-  const hpComponent = entity.getComponent('HP')
-  if (hpComponent.hp > 0) return true
-  return false
+  const hp = entity.getComponent('HP')
+  return hp.isAlive
 }

--- a/src/game/ai/entity/common/condition/isAlive.ts
+++ b/src/game/ai/entity/common/condition/isAlive.ts
@@ -2,5 +2,5 @@ import { Entity } from '@core/ecs/entity'
 
 export const isAlive = (entity: Entity) => (): boolean => {
   const hp = entity.getComponent('HP')
-  return hp.isAlive
+  return hp.hp > 0
 }

--- a/src/game/components/attackComponent.ts
+++ b/src/game/components/attackComponent.ts
@@ -4,7 +4,9 @@ export class AttackComponent {
   public constructor(
     // 与えたいダメージ量
     public damage: number,
-    // 攻撃元
-    public entity: Entity
+    // ダメージを与えたときに死ぬかどうか
+    public shouldCounterbalance: boolean,
+    // ダメージを与えないEntity
+    public ignoreList: Array<Entity> = []
   ) {}
 }

--- a/src/game/components/attackComponent.ts
+++ b/src/game/components/attackComponent.ts
@@ -2,7 +2,7 @@ export class AttackComponent {
   public constructor(
     // 与えたいダメージ量
     public damage: number,
-    // ダメージを与えたときに死ぬかどうか
+    // ダメージを与えたときにこのAttackComponentを所有するEntityがworldからremoveされるかどうか
     public shouldCounterbalance: boolean
   ) {}
 }

--- a/src/game/components/attackComponent.ts
+++ b/src/game/components/attackComponent.ts
@@ -1,12 +1,8 @@
-import { Entity } from '@core/ecs/entity'
-
 export class AttackComponent {
   public constructor(
     // 与えたいダメージ量
     public damage: number,
     // ダメージを与えたときに死ぬかどうか
-    public shouldCounterbalance: boolean,
-    // ダメージを与えないEntity
-    public ignoreList: Array<Entity> = []
+    public shouldCounterbalance: boolean
   ) {}
 }

--- a/src/game/components/hpComponent.ts
+++ b/src/game/components/hpComponent.ts
@@ -1,15 +1,15 @@
 export class HPComponent {
-  public constructor(private hp: number, private maxHp: number) {}
+  public constructor(private _hp: number, private maxHp: number) {}
 
   decrease(damage: number): void {
-    this.hp = Math.max(0, this.hp - damage)
+    this._hp = Math.max(0, this.hp - damage)
   }
 
   get ratio(): number {
     return this.hp / this.maxHp
   }
 
-  get isAlive(): boolean {
-    return this.hp > 0
+  get hp(): number {
+    return this._hp
   }
 }

--- a/src/game/components/hpComponent.ts
+++ b/src/game/components/hpComponent.ts
@@ -1,3 +1,15 @@
 export class HPComponent {
-  public constructor(public hp: number, public maxHp: number) {}
+  public constructor(private hp: number, private maxHp: number) {}
+
+  decrease(damage: number): void {
+    this.hp = Math.max(0, this.hp - damage)
+  }
+
+  get ratio(): number {
+    return this.hp / this.maxHp
+  }
+
+  get isAlive(): boolean {
+    return this.hp > 0
+  }
 }

--- a/src/game/entities/bulletFactory.ts
+++ b/src/game/entities/bulletFactory.ts
@@ -76,7 +76,7 @@ export class BulletFactory extends EntityFactory {
     collider.createCollider(aabbBody)
 
     // 攻撃判定
-    const attack = new AttackComponent(1, this.shooter)
+    const attack = new AttackComponent(1, true)
 
     const attackHitBox = new AABBDef(
       new Vec2(this.ATTACK_HIT_BOX_WIDTH, this.ATTACK_HIT_BOX_HEIGHT),

--- a/src/game/entities/enemy1Factory.ts
+++ b/src/game/entities/enemy1Factory.ts
@@ -9,7 +9,6 @@ import { ColliderComponent, AABBDef } from '@game/components/colliderComponent'
 import { CategoryList } from './category'
 import { AttackComponent } from '@game/components/attackComponent'
 import { HPComponent } from '@game/components/hpComponent'
-import { InvincibleComponent } from '@game/components/invincibleComponent'
 import { AIComponent } from '@game/components/aiComponent'
 import { parseAnimation } from '@core/graphics/animationParser'
 import { AnimationStateComponent } from '@game/components/animationStateComponent'
@@ -43,7 +42,6 @@ export class Enemy1Factory extends EntityFactory {
     const direction = new HorizontalDirectionComponent('Right')
     const collider = new ColliderComponent(entity)
     const hp = new HPComponent(2, 2)
-    const invincible = new InvincibleComponent()
 
     const aabbBody = new AABBDef(new Vec2(this.WIDTH, this.HEIGHT), CategoryList.enemy.body)
     aabbBody.tag.add('enemy1Body')
@@ -93,7 +91,6 @@ export class Enemy1Factory extends EntityFactory {
     entity.addComponent('Draw', draw)
     entity.addComponent('Collider', collider)
     entity.addComponent('Attack', attack)
-    entity.addComponent('Invincible', invincible)
     entity.addComponent('HP', hp)
     entity.addComponent('AnimationState', animState)
     return entity

--- a/src/game/entities/enemy1Factory.ts
+++ b/src/game/entities/enemy1Factory.ts
@@ -57,7 +57,7 @@ export class Enemy1Factory extends EntityFactory {
     collider.createCollider(hitBox)
 
     // 攻撃判定
-    const attack = new AttackComponent(1, entity)
+    const attack = new AttackComponent(1, false)
 
     const attackHitBox = new AABBDef(
       new Vec2(this.ATTACK_HIT_BOX_WIDTH, this.ATTACK_HIT_BOX_HEIGHT),

--- a/src/game/entities/snibeeFactory.ts
+++ b/src/game/entities/snibeeFactory.ts
@@ -9,7 +9,6 @@ import { ColliderComponent, AABBDef } from '@game/components/colliderComponent'
 import { CategoryList } from './category'
 import { AttackComponent } from '@game/components/attackComponent'
 import { HPComponent } from '@game/components/hpComponent'
-import { InvincibleComponent } from '@game/components/invincibleComponent'
 import { AIComponent } from '@game/components/aiComponent'
 import { parseAnimation } from '@core/graphics/animationParser'
 import { AnimationStateComponent } from '@game/components/animationStateComponent'
@@ -43,7 +42,6 @@ export class SnibeeFactory extends EntityFactory {
     const direction = new HorizontalDirectionComponent('Right')
     const collider = new ColliderComponent(entity)
     const hp = new HPComponent(2, 2)
-    const invincible = new InvincibleComponent()
 
     const aabbBody = new AABBDef(new Vec2(this.WIDTH, this.HEIGHT), CategoryList.enemy.body)
     aabbBody.tag.add('snibeeBody')
@@ -92,7 +90,6 @@ export class SnibeeFactory extends EntityFactory {
     entity.addComponent('Draw', draw)
     entity.addComponent('Collider', collider)
     entity.addComponent('Attack', attack)
-    entity.addComponent('Invincible', invincible)
     entity.addComponent('HP', hp)
     entity.addComponent('AnimationState', animState)
     return entity

--- a/src/game/entities/snibeeFactory.ts
+++ b/src/game/entities/snibeeFactory.ts
@@ -57,7 +57,7 @@ export class SnibeeFactory extends EntityFactory {
     collider.createCollider(hitBox)
 
     // 攻撃判定
-    const attack = new AttackComponent(1, entity)
+    const attack = new AttackComponent(1, false)
 
     const attackHitBox = new AABBDef(
       new Vec2(this.ATTACK_HIT_BOX_WIDTH, this.ATTACK_HIT_BOX_HEIGHT),

--- a/src/game/systems/damageSystem.ts
+++ b/src/game/systems/damageSystem.ts
@@ -47,7 +47,8 @@ export class DamageSystem extends System {
     const target = targetCollider.entity
 
     const attack = attacker.getComponent('Attack')
-    if (attack.entity === attacker) return // prevent self attack
+
+    if (attack.ignoreList.includes(target)) return
 
     if (target.hasComponent('HP') === false) return
     const targetHP = target.getComponent('HP')
@@ -56,8 +57,14 @@ export class DamageSystem extends System {
       const invincible = target.getComponent('Invincible')
       if (invincible.isInvincible()) return
       invincible.setInvincible()
+    } else {
+      attack.ignoreList.push(target) // prevent double attack to non-invincible entity
     }
     targetHP.decrease(attack.damage)
-    this.world.removeEntity(attacker)
+
+    // if manually remove by adding callback to do it,
+    // the order of call can influence the result
+    // to ignore that, damage system also has a responsibility to remove entity
+    if (attack.shouldCounterbalance) this.world.removeEntity(attacker)
   }
 }

--- a/src/game/systems/damageSystem.ts
+++ b/src/game/systems/damageSystem.ts
@@ -39,19 +39,25 @@ export class DamageSystem extends System {
     }
   }
 
-  private attackCollisionCallback = (hitbox: Collider, other: Collider): void => {
-    // AttackComponent持ってるEntityのColliderComponentと
-    // HPComponentとInvincibleComponent持ちEntityとの衝突を見てHPを減らす
-    const entity = other.entity
+  private attackCollisionCallback = (
+    attackerCollider: Collider,
+    targetCollider: Collider
+  ): void => {
+    const attacker = attackerCollider.entity
+    const target = targetCollider.entity
 
-    if (entity.hasComponent('HP') && entity.hasComponent('Invincible')) {
-      const hp = entity.getComponent('HP')
-      const invincible = entity.getComponent('Invincible')
-      const attack = hitbox.entity.getComponent('Attack')
-      if (!invincible.isInvincible() && attack.entity !== entity) {
-        hp.hp = Math.max(0, hp.hp - attack.damage)
-        invincible.setInvincible()
-      }
+    const attack = attacker.getComponent('Attack')
+    if (attack.entity === attacker) return // prevent self attack
+
+    if (target.hasComponent('HP') === false) return
+    const targetHP = target.getComponent('HP')
+
+    if (target.hasComponent('Invincible')) {
+      const invincible = target.getComponent('Invincible')
+      if (invincible.isInvincible()) return
+      invincible.setInvincible()
     }
+    targetHP.decrease(attack.damage)
+    this.world.removeEntity(attacker)
   }
 }

--- a/src/game/systems/damageSystem.ts
+++ b/src/game/systems/damageSystem.ts
@@ -48,8 +48,6 @@ export class DamageSystem extends System {
 
     const attack = attacker.getComponent('Attack')
 
-    if (attack.ignoreList.includes(target)) return
-
     if (target.hasComponent('HP') === false) return
     const targetHP = target.getComponent('HP')
 
@@ -57,8 +55,6 @@ export class DamageSystem extends System {
       const invincible = target.getComponent('Invincible')
       if (invincible.isInvincible()) return
       invincible.setInvincible()
-    } else {
-      attack.ignoreList.push(target) // prevent double attack to non-invincible entity
     }
     targetHP.decrease(attack.damage)
 

--- a/src/game/systems/uiSystem.ts
+++ b/src/game/systems/uiSystem.ts
@@ -64,7 +64,7 @@ export default class UiSystem extends System {
     const hp = player.getComponent('HP')
     this.playerHpGauge.clear()
     this.playerHpGauge.beginFill(0x30ff70)
-    this.playerHpGauge.drawRect(0, 0, (hp.hp / hp.maxHp) * windowSize.width, 16)
+    this.playerHpGauge.drawRect(0, 0, hp.ratio * windowSize.width, 16)
     this.playerHpGauge.endFill()
   }
 
@@ -119,7 +119,7 @@ export default class UiSystem extends System {
     for (const entity of this.hpFamily.entityIterator) {
       const hp = entity.getComponent('HP')
       const position = entity.getComponent('Position')
-      this.hpGauge.drawRect(position.x - 8, position.y - 12, (hp.hp / hp.maxHp) * 16, 2)
+      this.hpGauge.drawRect(position.x - 8, position.y - 12, hp.ratio * 16, 2)
     }
     this.hpGauge.endFill()
   }


### PR DESCRIPTION
- AttackComponentからentityが消えた
    - もともと攻撃者自身にダメージが行くのを防ぐ目的で使われていたが、Categoryがあるのでもう大丈夫
- AttackComponentにshouldCounterbalanceを追加
    - 弾丸のように「ダメージを与えたときに相殺する」という処理をしたいとき、自分でcallbackを追加してremoveEntityするという手もあるが、そうするとremoveEntityのcallbackとdamageのcallbackの呼び出される順序に依存して結果が大きく変わってしまう。現状2つのcallbackを登録する箇所は別々のところにあり、これらの呼び出し順序を気にできるような設計にはなっていないので、そもそも2つのcallbackを追加するというのをやめたい。そうするとdamageのcallback内でremoveEntityをする必要が出てくるので、そのためのフラグとして追加した。
- HPComponentをカプセル化
- Damage SystemでInvincibleを持っていない敵にも攻撃が通るようにした