### PR TITLE
プレイヤーが歩行アニメーションしない問題の修正

### DIFF
--- a/res/animation/player.json
+++ b/res/animation/player.json
@@ -3,7 +3,7 @@
     "name": "player",
     "state": {
       "Standing": [0],
-      "Walking": [0, 1],
+      "Walking": [1, 0],
       "Jumping": [1],
       "Dying": [2]
     },

--- a/src/game/ai/entity/common/action/animate.ts
+++ b/src/game/ai/entity/common/action/animate.ts
@@ -1,19 +1,17 @@
 import { Behaviour } from '@core/behaviour/behaviour'
 import { Entity } from '@core/ecs/entity'
 
-export const animate = function*(entity: Entity, animationName: string): Behaviour<void> {
+export const animate = function*(entity: Entity, animationName?: string): Behaviour<void> {
   const animationState = entity.getComponent('AnimationState')
-  animationState.state = animationName
-  const animation = animationState.animation
-  yield* animation.animate()
+  if (animationName) animationState.state = animationName
+  yield* animationState.animation.animate()
 }
 
 export const animateLoop = function*(
   entity: Entity,
-  animationName: string,
+  animationName?: string,
   loopCount = Infinity
 ): Behaviour<void> {
-  entity.getComponent('AnimationState').state = animationName
   for (let i = 0; i < loopCount; i++) {
     yield* animate(entity, animationName)
   }

--- a/src/game/ai/entity/player/playerAI.ts
+++ b/src/game/ai/entity/player/playerAI.ts
@@ -20,7 +20,7 @@ export const playerControl = function*(entity: Entity, world: World): Behaviour<
     playerJet(entity, world),
     playerPickup(entity),
     playerItemAction(entity),
-    animateLoop(entity, 'Standing'),
+    animateLoop(entity),
     invincibleTime(entity),
   ])
 }


### PR DESCRIPTION
`animateLoop`でstateを指定しなくても良いように修正。
プレイヤーのアニメーションの状態はplayerMoveAIで直接弄っているので、これでいい感じになるはず