### PR TITLE
プレイヤーのアニメーションがまだバグってたので修正

### DIFF
--- a/src/game/ai/entity/common/action/animate.ts
+++ b/src/game/ai/entity/common/action/animate.ts
@@ -11,12 +11,11 @@ export type AnimationOption = {
 export const animate = function*(option: AnimationOption): Behaviour<void> {
   const entity = option.entity
   const animationState = entity.getComponent('AnimationState')
-  const state = option.state ?? animationState.state
   const loopCount = option.loopCount ?? 1
   const waitFrames = option.waitFrames
 
   for (let i = 0; i < loopCount; i++) {
-    animationState.state = state
+    animationState.state = option.state ?? animationState.state
     yield* animationState.animation.animate(waitFrames)
   }
 }


### PR DESCRIPTION
`animate`関数に`state`オプションを渡さないと常にデフォルトステートが使われてたので直した